### PR TITLE
Allow to request a different number of rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "calvium-secure-password-validator",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calvium-secure-password-validator",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A validator for secure passwords",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,14 @@ function checkWhiteSpace(input) {
   return {valid: false, message: messages.noSpaces};
 }
 
-function checkMeetsMinimumCharacterClasses(input) {
+function checkMeetsMinimumCharacterClasses(input, numRules) {
   const checks = [regex.uppercase, regex.lowercase, regex.digits, regex.symbols];
 
   const passes = checks.reduce((ac, reg) => {
     return reg.test(input) ? ac + 1 : ac;
   }, 0);
-  if (passes >= params.MIN_CLASSES) {
+  const minClasses = numRules || params.MIN_CLASSES;
+  if (passes >= minClasses) {
     return {valid: true};
   }
   return {
@@ -34,14 +35,15 @@ function checkMeetsMinimumCharacterClasses(input) {
  *
  * @param input {string} password string to try out. null or undefined return false;
  * @param isAdmin {boolean} true if we have additional password requirements for admin users.
+ * @param numRules {number} num of rules that must match if falsy will use 3 as default
  * @returns {{valid: boolean, message?: string}}.  Message should be displayed in case of an invalid password. message is null if validate succeeded
  */
-function validate(input, isAdmin) {
+function validate(input, isAdmin, numRules) {
   let test = checkLength(input, isAdmin);
   if (!test.valid) return test;
   test = checkWhiteSpace(input);
   if (!test.valid) return test;
-  test = checkMeetsMinimumCharacterClasses(input);
+  test = checkMeetsMinimumCharacterClasses(input, numRules);
   if (!test.valid) return test;
   return test;
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -12,8 +12,8 @@ test('non admin: 7 chars is too short', () => {
 });
 
 test('admin: 13 chars is too short', () => {
-  expect(validate('abcdefg', true).valid).toBe(false);
-  expect(validate('abcdefg', true).message).toBe('Password is too short. 14 is the minimum');
+  expect(validate('abcdefghijk', true).valid).toBe(false);
+  expect(validate('abcdefghijk', true).message).toBe('Password is too short. 14 is the minimum');
 });
 
 test('uppercase Euro works with accented chars and ASCII', () => {
@@ -86,11 +86,11 @@ test('has digit, upper, and symbol', () => {
 });
 
 
-test('various failures', () => {
-  const tests = ['11111!!!!', 'ò!aaaaa', 'aaaaaaaaaaaaaa', '±±±±±±±±±§§§±±§§±±'];
+test('various failures for 2 Rules', () => {
+  const tests = ['!@£$%^&*()', 'abcdefghi', '123456789', '±±±±±±±±±§§§±±§§±±'];
 
   tests.forEach(t => {
-    const actual = validate(t);
+    const actual = validate(t, false, 2);
     if (actual.valid) {
       console.log(`Unexpectedly passed password: ${t}`);
     }
@@ -98,15 +98,62 @@ test('various failures', () => {
   });
 });
 
+test('various failures for 3 Rules', () => {
+    const tests = ['11111!!!!', 'ò!aaaaa', 'aaaaaaaaaaaaaa', '±±±±±±±±±§§§±±§§±±', 'AAAA1111', 'AAAAaaaa'];
 
-test('various successes', () => {
-  const tests = ['%$$Ω1!@$'];
+    tests.forEach(t => {
+        const actual = validate(t, false, 3);
+        if (actual.valid) {
+            console.log(`Unexpectedly passed password: ${t}`);
+        }
+        expect(actual.valid).toBe(false);
+    });
+});
+
+test('various failures for 4 Rules', () => {
+    const tests = ['11111!!!!', 'ò!aaaaa', 'aaaaaaaaaaaaaa', '±±±±±±±±±§§§±±§§±±', '%$$Ω1!@$', 'AA11aabb', '@@@aaa111'];
+
+    tests.forEach(t => {
+        const actual = validate(t, false, 4);
+        if (actual.valid) {
+            console.log(`Unexpectedly passed password: ${t}`);
+        }
+        expect(actual.valid).toBe(false);
+    });
+});
+
+test('various successes with 2 rules', () => {
+    const tests = ['%$$Ω1!@$', 'AAAA1111', 'AAAAaaaa'];
+
+    tests.forEach(t => {
+        const actual = validate(t, false, 2);
+        if (!actual.valid) {
+            console.log(`Unexpectedly failed password: ${t}`);
+        }
+        expect(actual.valid).toBe(true);
+    });
+});
+
+test('various successes with 3 rules', () => {
+  const tests = ['%$$Ω1!@$', 'AA11aabb', '@@@aaa111'];
 
   tests.forEach(t => {
     const actual = validate(t);
-    if (actual.valid) {
+    if (!actual.valid) {
       console.log(`Unexpectedly failed password: ${t}`);
     }
     expect(actual.valid).toBe(true);
   });
+});
+
+test('various successes with 4 rules', () => {
+    const tests = ['%$$Ω1!@$a', 'A1a!bbbb', ',.<>Aa1b'];
+
+    tests.forEach(t => {
+        const actual = validate(t, false, 4);
+        if (!actual.valid) {
+            console.log(`Unexpectedly failed password: ${t}`);
+        }
+        expect(actual.valid).toBe(true);
+    });
 });


### PR DESCRIPTION
Minimum changes to api to allow to submit a configurable number of rules to use, now is possible to request 2, 3 or 4 rules.

Default to the previous hardcoded number of rules.
Update the tests to cover the new functionality.
Bump version number